### PR TITLE
delete #main's v-show

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -36,12 +36,12 @@
                 </div>
             </transition>
             <%- partial("menu") %>
-            <transition name="into">
-                <div id="main">
+            <!-- <transition name="into"> -->
+            <div id="main" class="into-enter-from">
                     <%- partial(type) %>
                     <%- partial("footer") %>
                 </div>
-            </transition>
+            <!-- </transition> -->
             <% if (theme.preview.enable) { %>
             <transition name="fade">
                 <div id="preview" ref="preview" v-show="previewShow">

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -37,7 +37,7 @@
             </transition>
             <%- partial("menu") %>
             <transition name="into">
-                <div id="main" v-show="!loading">
+                <div id="main">
                     <%- partial(type) %>
                     <%- partial("footer") %>
                 </div>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -36,12 +36,10 @@
                 </div>
             </transition>
             <%- partial("menu") %>
-            <!-- <transition name="into"> -->
-            <div id="main" class="into-enter-from">
-                    <%- partial(type) %>
-                    <%- partial("footer") %>
-                </div>
-            <!-- </transition> -->
+            <div id="main" :class="loading ? 'into-enter-from': 'into-enter-active'">
+                <%- partial(type) %>
+                <%- partial("footer") %>
+            </div>
             <% if (theme.preview.enable) { %>
             <transition name="fade">
                 <div id="preview" ref="preview" v-show="previewShow">

--- a/source/css/main.css
+++ b/source/css/main.css
@@ -576,12 +576,10 @@ body::-webkit-scrollbar-track {
 .input:hover {
     background: #fff;
 }
-.into-enter-active,
-.into-leave-active {
+.into-enter-active {
     transition: opacity 0.5s, transform 0.5s;
 }
-.into-enter-from,
-.into-leave-to {
+.into-enter-from {
     opacity: 0;
     transform: scale(1.1);
 }

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -13,6 +13,7 @@ const app = Vue.createApp({
     created() {
         window.addEventListener("load", () => {
             this.loading = false;
+            document.getElementById("main").className = "into-enter-active";
         });
     },
     mounted() {

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -13,7 +13,6 @@ const app = Vue.createApp({
     created() {
         window.addEventListener("load", () => {
             this.loading = false;
-            document.getElementById("main").className = "into-enter-active";
         });
     },
     mounted() {


### PR DESCRIPTION
#loading的z-index已为最高，所以加载时不必隐藏main，这样做的好处是可以使图片懒加载插件( https://github.com/Troy-Yang/hexo-lazyload-image )正常工作
同时手动实现了main的Transition，使得删掉其v-show后动画不受影响