### PR TITLE
换用 CDN 为 ZStatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [ParticleX](https://github.com/theme-particlex/hexo-theme-particlex) 主题，诞生原因是因为原来的 [Particle](https://github.com/korilin/hexo-theme-particle) 主题不维护了，但是我觉得还是很好的。
 
-原来用的是 Vue 2 + Ant Design Vue 1，现更新到 Vue 3，去除 Ant Design Vue 采用自定义样式，图标更改为 Font Awesome 6，CDN 改为 Staticfile。
+原来用的是 Vue 2 + Ant Design Vue 1，现更新到 Vue 3，去除 Ant Design Vue 采用自定义样式，图标更改为 Font Awesome 6，CDN 改为 ZStatic。
 
 原项目 `README.md` 里说：
 

--- a/layout/import.ejs
+++ b/layout/import.ejs
@@ -1,6 +1,6 @@
-<link rel="preconnect" href="https://cdn.staticfile.net" />
-<script src="https://cdn.staticfile.net/vue/3.3.7/vue.global.prod.min.js"></script>
-<link rel="stylesheet" href="https://cdn.staticfile.net/font-awesome/6.4.2/css/all.min.css" />
+<link rel="preconnect" href="https://s4.zstatic.net" />
+<script src="https://s4.zstatic.net/ajax/libs/vue/3.3.7/vue.global.prod.min.js"></script>
+<link rel="stylesheet" href="https://s4.zstatic.net/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
 <link rel="preconnect" href="https://fonts.loli.net" />
 <link rel="preconnect" href="https://gstatic.loli.net" crossorigin />
 <link rel="stylesheet" href="https://fonts.loli.net/css2?family=Fira+Code:wght@400;500;600;700&family=Lexend:wght@400;500;600;700;800;900&family=Noto+Sans+SC:wght@400;500;600;700;800;900&display=swap" />
@@ -9,25 +9,25 @@
 <script src="https://polyfill.io/v3/polyfill.min.js?features=<%- theme.polyfill.features %>"></script>
 <% } %>
 <% if (theme.highlight.enable) { %>
-<script src="https://cdn.staticfile.net/highlight.js/11.9.0/highlight.min.js"></script>
-<script src="https://cdn.staticfile.net/highlightjs-line-numbers.js/2.8.0/highlightjs-line-numbers.min.js"></script>
+<script src="https://s4.zstatic.net/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://s4.zstatic.net/ajax/libs/highlightjs-line-numbers.js/2.8.0/highlightjs-line-numbers.min.js"></script>
 <link
     rel="stylesheet"
-    href="https://cdn.staticfile.net/highlight.js/11.9.0/styles/<%- theme.highlight.style %>.min.css"
+    href="https://s4.zstatic.net/ajax/libs/highlight.js/11.9.0/styles/<%- theme.highlight.style %>.min.css"
 />
 <script src="<%- url_for("/js/lib/highlight.js") %>"></script>
 <% } %>
 <% if (theme.math.enable) { %>
-<script src="https://cdn.staticfile.net/KaTeX/0.16.9/katex.min.js"></script>
-<script src="https://cdn.staticfile.net/KaTeX/0.16.9/contrib/auto-render.min.js"></script>
-<link rel="stylesheet" href="https://cdn.staticfile.net/KaTeX/0.16.9/katex.min.css" />
+<script src="https://s4.zstatic.net/ajax/libs/KaTeX/0.16.9/katex.min.js"></script>
+<script src="https://s4.zstatic.net/ajax/libs/KaTeX/0.16.9/contrib/auto-render.min.js"></script>
+<link rel="stylesheet" href="https://s4.zstatic.net/ajax/libs/KaTeX/0.16.9/katex.min.css" />
 <script src="<%- url_for("/js/lib/math.js") %>"></script>
 <% } %>
 <% if (theme.preview.enable) { %>
 <script src="<%- url_for("/js/lib/preview.js") %>"></script>
 <% } %>
 <% if (theme.crypto.enable && typeof page.secret !== "undefined") { %>
-<script src="https://cdn.staticfile.net/crypto-js/4.2.0/crypto-js.min.js"></script>
+<script src="https://s4.zstatic.net/ajax/libs/crypto-js/4.2.0/crypto-js.min.js"></script>
 <script src="<%- url_for("/js/lib/crypto.js") %>"></script>
 <% } %>
 <% if (type === "archives" && theme.search.enable) { %>
@@ -35,16 +35,16 @@
 <% } %>
 <% if (type === "post" && page.comments) { %>
 <% if (theme.gitalk.enable) { %>
-<script src="https://cdn.staticfile.net/gitalk/1.8.0/gitalk.min.js"></script>
-<link rel="stylesheet" href="https://cdn.staticfile.net/gitalk/1.8.0/gitalk.min.css" />
+<script src="https://s4.zstatic.net/ajax/libs/gitalk/1.8.0/gitalk.min.js"></script>
+<link rel="stylesheet" href="https://s4.zstatic.net/ajax/libs/gitalk/1.8.0/gitalk.min.css" />
 <% } %>
 <% if (theme.waline.enable) { %>
-<script src="https://cdn.staticfile.net/waline/2.15.8/waline.min.js"></script>
-<link rel="stylesheet" href="https://cdn.staticfile.net/waline/2.15.8/waline.min.css" />
-<link rel="stylesheet" href="https://cdn.staticfile.net/waline/2.15.8/waline-meta.min.css" />
+<script src="https://s4.zstatic.net/ajax/libs/waline/2.15.8/waline.min.js"></script>
+<link rel="stylesheet" href="https://s4.zstatic.net/ajax/libs/waline/2.15.8/waline.min.css" />
+<link rel="stylesheet" href="https://s4.zstatic.net/ajax/libs/waline/2.15.8/waline-meta.min.css" />
 <% } %>
 <% if (theme.twikoo.enable) { %>
-<script src="https://cdn.staticfile.net/twikoo/1.6.22/twikoo.all.min.js"></script>
+<script src="https://s4.zstatic.net/ajax/libs/twikoo/1.6.31/twikoo.all.min.js"></script>
 <% } %>
 <% } %>
 <% if (type === "index") { %>


### PR DESCRIPTION
[StaticFile](https://www.staticfile.net/) 稳定性堪忧（参见 staticfile/static/issues/677 和 staticfile/static/issues/662 等），故建议移除对 [StaticFile](https://www.staticfile.net/) 的默认支持，更换为 [ZStatic](https://www.zstatic.net/services/)。

之所以选择 [ZStatic](https://www.zstatic.net/services/)，是因为综合考虑下其比较优秀：[ElemeCDN](https://npm.elemecdn.com/)、[Zhimg](https://unpkg.zhimg.com/) 等均为企业私用 CDN，极其不稳定；[StaticFile](https://www.staticfile.net/)、[BootCDN](https://www.bootcdn.cn/) 频频[出问题](http://ksria.com/sov2ex/?q=bootcdn)，无法投入项目等生产环境；[字节跳动静态资源公共库](https://cdn.bytedance.com/)倒是比较稳定，但太旧了，满足不了需求；[CBD Unpkg](https://cdn.cbd.int/) 为生物多样性公约官网的私用 CDN，滥用违反道义，且速度很慢；[南方科技大学开源软件镜像站](https://mirrors.sustech.edu.cn/help/cdnjs.html)只有一个 IP，没有 CDN 的加持，不适合国外用户，不可以放入国际性项目。